### PR TITLE
feat(auth): Add password reset functionality with OTP verification

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -13,6 +13,7 @@ import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto, VerifyOtpDto } from './dto/login.dto';
+import { ForgotPasswordDto, VerifyResetOtpDto, ResetPasswordDto } from './dto/forgot-password.dto';
 import { VerifyGoogleTokenDto, VerifyFacebookTokenDto } from './dto/verify-token.dto';
 import { GoogleAuthGuard } from './guards/google-auth.guard';
 import { FacebookAuthGuard } from './guards/facebook-auth.guard';
@@ -112,6 +113,60 @@ export class AuthController {
   })
   async resendOtp(@Body() body: { email: string }) {
     return this.authService.sendEmailVerification(body.email);
+  }
+
+  @Post('forgot-password')
+  @ApiOperation({ summary: 'Request password reset OTP' })
+  @ApiBody({ type: ForgotPasswordDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Password reset OTP sent if account exists',
+    schema: {
+      example: {
+        message: 'If an account exists with this email, a password reset code has been sent.',
+      },
+    },
+  })
+  async forgotPassword(@Body() forgotPasswordDto: ForgotPasswordDto) {
+    return this.authService.forgotPassword(forgotPasswordDto.email);
+  }
+
+  @Post('verify-reset-otp')
+  @ApiOperation({ summary: 'Verify password reset OTP' })
+  @ApiBody({ type: VerifyResetOtpDto })
+  @ApiResponse({
+    status: 200,
+    description: 'OTP verified successfully',
+    schema: {
+      example: {
+        message: 'OTP verified successfully. You can now reset your password.',
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Invalid or expired OTP' })
+  async verifyResetOtp(@Body() verifyResetOtpDto: VerifyResetOtpDto) {
+    return this.authService.verifyResetOtp(verifyResetOtpDto.email, verifyResetOtpDto.otp);
+  }
+
+  @Post('reset-password')
+  @ApiOperation({ summary: 'Reset password with OTP' })
+  @ApiBody({ type: ResetPasswordDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Password reset successfully',
+    schema: {
+      example: {
+        message: 'Password reset successfully. You can now login with your new password.',
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Invalid or expired OTP' })
+  async resetPassword(@Body() resetPasswordDto: ResetPasswordDto) {
+    return this.authService.resetPassword(
+      resetPasswordDto.email,
+      resetPasswordDto.otp,
+      resetPasswordDto.newPassword,
+    );
   }
 
   @Get('google')

--- a/src/auth/dto/forgot-password.dto.ts
+++ b/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,53 @@
+import { IsEmail, IsString, MinLength, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ForgotPasswordDto {
+  @ApiProperty({
+    example: 'user@example.com',
+    description: 'Email address to send password reset OTP',
+  })
+  @IsEmail()
+  email: string;
+}
+
+export class VerifyResetOtpDto {
+  @ApiProperty({
+    example: 'user@example.com',
+    description: 'Email address',
+  })
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({
+    example: '123456',
+    description: '6-digit OTP code',
+  })
+  @IsString()
+  @Matches(/^\d{6}$/, { message: 'OTP must be a 6-digit number' })
+  otp: string;
+}
+
+export class ResetPasswordDto {
+  @ApiProperty({
+    example: 'user@example.com',
+    description: 'Email address',
+  })
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({
+    example: '123456',
+    description: '6-digit OTP code',
+  })
+  @IsString()
+  @Matches(/^\d{6}$/, { message: 'OTP must be a 6-digit number' })
+  otp: string;
+
+  @ApiProperty({
+    example: 'NewPassword123!',
+    description: 'New password (min 8 characters)',
+  })
+  @IsString()
+  @MinLength(8, { message: 'Password must be at least 8 characters long' })
+  newPassword: string;
+}


### PR DESCRIPTION
- Add forgot-password, verify-reset-otp, and reset-password endpoints to auth controller
- Create ForgotPasswordDto, VerifyResetOtpDto, and ResetPasswordDto for request validation
- Implement forgotPassword service method to generate and send reset OTP via email
- Implement verifyResetOtp service method to validate OTP before password reset
- Implement resetPassword service method to update user password after OTP verification
- Add password reset email template to email service with OTP delivery
- Store reset OTP in Redis with 10-minute expiration for security
- Add validation to prevent password reset for non-local authentication providers
- Include comprehensive API documentation with Swagger decorators for all new endpoints